### PR TITLE
fix: filter out actions with no geolocation data

### DIFF
--- a/src/components/space/ActionsMap.js
+++ b/src/components/space/ActionsMap.js
@@ -48,14 +48,16 @@ function ActionsMap() {
   const { actions } = useContext(SpaceDataContext);
 
   // GeoJSON Feature objects
-  const points = actions.map((action) => ({
-    type: 'Feature',
-    properties: { cluster: false, actionId: action._id },
-    geometry: {
-      type: 'Point',
-      coordinates: [action.geolocation.ll[1], action.geolocation.ll[0]],
-    },
-  }));
+  const points = actions
+    .filter((action) => action.geolocation)
+    .map((action) => ({
+      type: 'Feature',
+      properties: { cluster: false, actionId: action._id },
+      geometry: {
+        type: 'Point',
+        coordinates: [action.geolocation.ll[1], action.geolocation.ll[0]],
+      },
+    }));
 
   const { clusters } = useSupercluster({
     points,


### PR DESCRIPTION
there are actions which have geolocation: null, and this was causing issues when converting actions to GeoJSON feature objects used by useSupercluster.

closes #38