### PR TITLE
ci: update outdated trigger branches in workflows

### DIFF
--- a/.github/workflows/cintegration-s3-caller.yml
+++ b/.github/workflows/cintegration-s3-caller.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - master
 
   # Allows to run the workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches-ignore:
       - main
-      - master
 
 # This workflow is made up of one job that calls the reusable workflow in graasp-deploy
 jobs:

--- a/.github/workflows/release-please-app.yml
+++ b/.github/workflows/release-please-app.yml
@@ -4,7 +4,7 @@ name: Release new app version
 on:
   push:
     branches:
-      - "master"
+      - "main"
 
 jobs:
   release-please:


### PR DESCRIPTION
This PR updates trigger branches in workflows.

The default branch was renamed from `master` to `main`.
